### PR TITLE
fix homepage links

### DIFF
--- a/overrides/home.html
+++ b/overrides/home.html
@@ -321,7 +321,7 @@
         <p>It'll show you how to take a process you currently do in a very manual, time-consuming way, and rebuild it in-line with RAP principles.</p>
         <p>Learn more:</p>
         <a
-          href="{{ base_url }}/implementing_RAP/rap-readiness/"
+          href="{{ base_url }}/implementing_RAP/"
           title="{{ page.next_page.title | striptags }}"
           class="md-button md-button--primary"
         >
@@ -427,7 +427,7 @@
         </ul>
         <p>Learn more:</p>
         <a
-          href="{{ base_url }}/training_resources/git/introduction-to-git/"
+          href="{{ base_url }}/training_resources/"
           class="md-button md-button--primary"
         >
           Training Resources


### PR DESCRIPTION
❓**What**: updates links from homepage to point to the correct landing pages for each section

🧠**Why?**: So that the links point to the right places

👨‍💻**How?**: By updating the links

# Checklist:
Have checked for the following:
- [ ] The website still builds correctly, and you can view it using `mkdocs serve`.
- [ ] There are no new "warnings" from mkdocs
- [ ] Does your page follow the [page template](https://nhsdigital.github.io/rap-community-of-practice/example_RAP_CoP_page/) (or [here in Markdown](https://github.com/NHSDigital/rap-community-of-practice/blob/main/docs/example_RAP_CoP_page.md))?
- [ ] Spelling errors
- [ ] Consistent capitalization
- [ ] Consistent numbers
- [ ] Material features incorrectly implemented: search for code blocks and markers (e.g. !!!).
- [ ] Code snippets don't work
- [ ] Images not working
- [ ] Links not working

## Where it was tested
<!-- 
Please describe the test configuration - below is an example.
-->
- Github Codespaces - 2-core, 4GB RAM, 32GB hard drive
- devcontainer.json describes further settings
