### PR TITLE
changed homepage bg colour from white to #f8f8f8

### DIFF
--- a/overrides/home.html
+++ b/overrides/home.html
@@ -25,7 +25,7 @@
   }
 
   .container--white {
-    background-color: white;
+    background-color: #f8f8f8;
     color: black;
   }
 


### PR DESCRIPTION
❓**What**: Changed background colour on home page from white to #f8f8f8 (light gray, matches rest of site)

🧠**Why?**: Accessibility

👨‍💻**How?**: updated CSS class container--white

# Checklist:
Have checked for the following: Yes
- [ ] The website still builds correctly, and you can view it using `mkdocs serve`.
- [ ] There are no new "warnings" from mkdocs
- [ ] Does your page follow the [page template](https://nhsdigital.github.io/rap-community-of-practice/example_RAP_CoP_page/) (or [here in Markdown](https://github.com/NHSDigital/rap-community-of-practice/blob/main/docs/example_RAP_CoP_page.md))?
- [ ] Spelling errors
- [ ] Consistent capitalization
- [ ] Consistent numbers
- [ ] Material features incorrectly implemented: search for code blocks and markers (e.g. !!!).
- [ ] Code snippets don't work
- [ ] Images not working
- [ ] Links not working

## Where it was tested
<!-- 
Please describe the test configuration - below is an example.
-->
- Github Codespaces - 2-core, 4GB RAM, 32GB hard drive
- devcontainer.json describes further settings
