### PR TITLE
Update pages-build-deployment.yml

### DIFF
--- a/.github/workflows/pages-build-deployment.yml
+++ b/.github/workflows/pages-build-deployment.yml
@@ -13,7 +13,7 @@ jobs:
   # This workflow contains a single job called "deploy"
   deploy:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -23,7 +23,10 @@ jobs:
       - name: "Setup Python"
         uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.12
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt-dev
 
       - name: "Install Python Packages"
         run: pip install -r requirements.txt


### PR DESCRIPTION
❓**What**: Fixed deployment error due to ubuntu-latest switching to 24.04

🧠**Why?**: Deployent failing

👨‍💻**How?**: 

- Pin ubuntu image to 22.04 (supported by GitHub until Sept 26)
- Pin Python to 3.12
- Add step to install libxml2-dev libxslt-dev

## Where it was tested

See deployment on fork here: https://warren-davies4.github.io/rap-community-of-practice/