### PR TITLE
Fix link hover color to be visible (#66)

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -66,7 +66,7 @@
 a.md-nav__link:hover,
 .md-typeset a:focus, 
 .md-typeset a:hover {
-  color: var(--md-primary-fg-color);
+  color: #ffeb3b;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
<!-- 
- Pull request title follows this format "SH NV-1234 Solves this problem":
    - Initials of author
    - associated Jira ticket number
    - brief description
- Choose appropriate labels
- Use the "development" sidebar option to indicate if this closes any open issues, etc.
-->
# Description
<!-- 
In the body of the pull request, provide a description following the "What, Why, How" approach. 

You could also add a gif using the "gifs for GitHub" Chrome extension: https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep/related?hl=en
-->

❓**What**: Fixed the link hover color so it's no longer the same as the background.

🧠**Why?**: Fixes #66 — links became invisible on hover because the hover color matched the blue background, which could confuse users.

👨‍💻**How?**: Changed the color value in the .md-typeset a:hover rule in docs/stylesheets/extra.css from the NHS blue variable to #ffeb3b (yellow) so hovered links stay visible against the blue background.

# Checklist:
Have checked for the following:
- [ ] The website still builds correctly, and you can view it using `mkdocs serve`.
- [ ] There are no new "warnings" from mkdocs
- [ ] Does your page follow the [page template](https://nhsdigital.github.io/rap-community-of-practice/example_RAP_CoP_page/) (or [here in Markdown](https://github.com/NHSDigital/rap-community-of-practice/blob/main/docs/example_RAP_CoP_page.md))?
- [ ] Spelling errors
- [ ] Consistent capitalization
- [ ] Consistent numbers
- [ ] Material features incorrectly implemented: search for code blocks and markers (e.g. !!!).
- [ ] Code snippets don't work
- [ ] Images not working
- [x] Links not working

## Where it was tested
<!-- 
Edited directly via GitHub's web editor. This was a small, single-line CSS color value change, so it wasn't tested locally with mkdocs serve - happy to verify with a maintainer or add a screenshot if needed.
-->
Edited directly via GitHub's web editor. This was a small, single-line CSS color value change, so it wasn't tested locally with mkdocs serve — happy to verify with a maintainer or add a screenshot if needed.