### PR TITLE
fix/broken-pyspark-guide-link

### DIFF
--- a/docs/training_resources/python/intro-to-python.md
+++ b/docs/training_resources/python/intro-to-python.md
@@ -128,7 +128,7 @@ Whatever the scale of your data, you might need to interact with it via SQL quer
 There are as many opinions about what constitutes good code as there are coders. It's also always a good idea to adhere to a style guide. 
 
 * For Python, we recommend using [`PEP-8`](https://peps.python.org/pep-0008/), which is also mentioned in our [Levels of RAP][levels_of_rap]
-* more specifically, the [Google Python style-guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md) (which is also the core of our [Pyspark style guide](../training_resources/pyspark/pyspark-style-guide/) )
+* more specifically, the [Google Python style-guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md) (which is also the core of our [Pyspark style guide](../../pyspark/pyspark-style-guide/) )
 * There are tools called **linters** which can be used to check for these styles automatically, such as [Pylint](https://pypi.org/project/pylint/)
 
 Next, you'll want to know [how to structure your Python projects](project-structure-and-packaging.md), [how to write good functions](python-functions.md), and [how to approach unit testing in Python](unit-testing.md).


### PR DESCRIPTION
<!-- 
- Pull request title follows this format "SH NV-1234 Solves this problem":
    - Initials of author
    - associated Jira ticket number
    - brief description
- Choose appropriate labels
- Use the "development" sidebar option to indicate if this closes any open issues, etc.
-->
# Description
<!-- 
In the body of the pull request, provide a description following the "What, Why, How" approach. 

You could also add a gif using the "gifs for GitHub" Chrome extension: https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep/related?hl=en
-->

❓**What**: fixes #78  broken link

🧠**Why?**: so the link will work

👨‍💻**How?**: change the link to one that works

# Checklist:
Have checked for the following:
- [ ] The website still builds correctly, and you can view it using `mkdocs serve`.
- [ ] There are no new "warnings" from mkdocs
- [ ] Does your page follow the [page template](https://nhsdigital.github.io/rap-community-of-practice/example_RAP_CoP_page/) (or [here in Markdown](https://github.com/NHSDigital/rap-community-of-practice/blob/main/docs/example_RAP_CoP_page.md))?
- [ ] Spelling errors
- [ ] Consistent capitalization
- [ ] Consistent numbers
- [ ] Material features incorrectly implemented: search for code blocks and markers (e.g. !!!).
- [ ] Code snippets don't work
- [ ] Images not working
- [ ] Links not working

## Where it was tested
<!-- 
Please describe the test configuration - below is an example.
-->
- Github Codespaces - 2-core, 4GB RAM, 32GB hard drive
- devcontainer.json describes further settings
